### PR TITLE
프로필 이미지 컴포넌트 수정

### DIFF
--- a/src/components/profile-img/ProfileImage.module.css
+++ b/src/components/profile-img/ProfileImage.module.css
@@ -45,7 +45,7 @@
   position: relative;
   overflow: hidden;
 
-  background: inherit;
+  background: transparent;
   border-radius: inherit;
 }
 
@@ -56,7 +56,7 @@
 /* border: breakpoint별 var로 대응 */
 .avatarBorder {
   border-style: solid;
-  border-color: #e2e8f0; 
+  border-color: #e2e8f0;
   border-width: var(--pi-border-base);
   box-sizing: border-box;
 }
@@ -74,12 +74,22 @@
   object-fit: contain;
 }
 
+.profileFallbackBg {
+  background: var(--color-background-tertiary, #e2e8f0);
+}
+
 /* radius */
+.r6 {
+  border-radius: 6px;
+}
 .r8 {
   border-radius: 8px;
 }
 .r12 {
   border-radius: 12px;
+}
+.r16 {
+  border-radius: 16px;
 }
 .r20 {
   border-radius: 20px;
@@ -96,7 +106,7 @@
 
   background: var(--color-background-tertiary);
   border-radius: 50%;
-  border: none; 
+  border: none;
   padding: 0;
   cursor: pointer;
 
@@ -106,6 +116,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+@media (max-width: 767px) {
+  .editButton {
+    border: 1px solid var(--color-background-inverse);
+  }
+
+  .r32 {
+    border-radius: 20px;
+  }
 }
 
 /* 아이콘 표시 제어 */
@@ -131,12 +151,6 @@
   }
 }
 
-@media (max-width: 767px) {
-  .r32 {
-    border-radius: 20px;
-  }
-}
-
 /* md 이상 */
 @media (min-width: 768px) {
   .box {
@@ -155,9 +169,7 @@
     right: 0;
     width: 32px;
     height: 32px;
-
-    /* ✅ md 버전에서만 흰색 보더 */
-    border: 1px solid var(--color-background-inverse);
+    border: none;
   }
 
   .pencilSmall {

--- a/src/components/profile-img/ProfileImage.tsx
+++ b/src/components/profile-img/ProfileImage.tsx
@@ -41,7 +41,7 @@ import TeamDefault from '@/assets/icons/img/img.svg';
 
 export type ProfileImageSize = 'xl' | 'lg' | 'md' | 'sm' | 'xs';
 export type ProfileImageVariant = 'profile' | 'team';
-export type ProfileImageRadius = 'r8' | 'r12' | 'r20' | 'r32';
+export type ProfileImageRadius = 'r6' | 'r8' | 'r12' | 'r16' | 'r20' | 'r32';
 
 type Breakpoint = 'base' | 'sm' | 'md' | 'lg' | 'xl';
 type SizeSpec = { box: number; image: number };
@@ -75,8 +75,8 @@ const SIZE_PRESET: Record<ProfileImageSize, SizeSpec> = {
   xl: { box: 112, image: 100 },
   lg: { box: 78, image: 64 },
   md: { box: 40, image: 32 },
-  sm: { box: 32, image: 24 },
-  xs: { box: 24, image: 16 },
+  sm: { box: 28, image: 24 },
+  xs: { box: 20, image: 20 },
 };
 
 const BP_ORDER: Breakpoint[] = ['base', 'sm', 'md', 'lg', 'xl'];
@@ -171,7 +171,7 @@ export default function ProfileImage({
   size = 'md',
   responsiveSize,
   responsiveSpec,
-  radius = 'r12',
+  radius = 'r16',
   editable = false,
   showEditButton = true,
   clickToEdit,
@@ -211,7 +211,12 @@ export default function ProfileImage({
   const isErrored = !!currentSrcKey && erroredSrc === currentSrcKey;
 
   const effectiveSrc = isErrored ? fallback : imageSrc || fallback;
-  const usingFallback = isErrored || !imageSrc;
+
+  const isFallback = isErrored || !imageSrc;
+
+  const fitClass = isFallback ? styles.contain : styles.cover;
+
+  const shouldProfileFallbackBg = variant === 'profile' && isFallback;
 
   const shouldClickToEdit = clickToEdit ?? (editable && !showEditButton);
 
@@ -242,6 +247,7 @@ export default function ProfileImage({
       setErroredSrc(null);
 
       // local preview
+
       const localUrl = URL.createObjectURL(file);
       setPreviewUrl((prev) => {
         if (prev?.startsWith('blob:')) URL.revokeObjectURL(prev);
@@ -297,9 +303,13 @@ export default function ProfileImage({
         <div className={`${styles.box} ${styles[radius]}`}>
           <div className={`${styles.mask} ${styles[radius]}`}>
             <div
-              className={`${styles.avatar} ${styles[radius]} ${hasBorder ? styles.avatarBorder : ''} ${
-                editable && shouldClickToEdit ? styles.clickable : ''
-              }`}
+              className={[
+                styles.avatar,
+                styles[radius],
+                hasBorder ? styles.avatarBorder : '',
+                editable && shouldClickToEdit ? styles.clickable : '',
+                shouldProfileFallbackBg ? styles.profileFallbackBg : '', // ✅ CHANGED
+              ].join(' ')}
               onClick={handleAvatarClick}
               onKeyDown={handleKeyDown}
               role={editable && shouldClickToEdit ? 'button' : undefined}
@@ -311,9 +321,7 @@ export default function ProfileImage({
                 alt={alt}
                 fill
                 sizes={sizesAttr}
-                className={`${styles.img} ${styles[radius]} ${
-                  usingFallback ? styles.contain : styles.cover
-                }`}
+                className={`${styles.img} ${styles[radius]} ${fitClass}`}
                 priority={priority}
                 loading={priority ? 'eager' : 'lazy'}
                 onError={() => {


### PR DESCRIPTION
## Summary
<img width="29" height="29" alt="스크린샷 2026-02-11 오전 5 36 43" src="https://github.com/user-attachments/assets/be9b0cd8-733a-4e67-951a-59f442ab22e2" />

- 프로필 이미지 버전 회색 배경 추가
- 에딧버튼 보더 모바일에서만 적용
- 라운딩 추가
- 

## Issue

-  #11 

- 특이사항
없음